### PR TITLE
Prevent error if system distribution can't be detected

### DIFF
--- a/src/Resources/translations/SystemInformationBundle.en.yaml
+++ b/src/Resources/translations/SystemInformationBundle.en.yaml
@@ -173,6 +173,7 @@ system:
       web: Webserver
       distribution: Distribution
       description: Server despcription
+      error: Unknown
     php:
       label: PHP
       version: PHP Version
@@ -188,6 +189,7 @@ system:
       label: App
       version: App version
       environment: App environment
+      error: Can't read version from composer.json
     symfony:
       label: Symfony
       version: Symfony version

--- a/src/Service/InformationService.php
+++ b/src/Service/InformationService.php
@@ -254,9 +254,9 @@ class InformationService
     }
 
     /**
-     * @return mixed|null
+     * @return string|null
      */
-    public function readAppVersion(): mixed
+    public function readAppVersion(): ?string
     {
         $composerFile = file_get_contents($this->container->getParameter('kernel.project_dir') . '/composer.json');
         if ($composerFile) {
@@ -332,7 +332,7 @@ class InformationService
     {
         return [
             'label' => $this->translator->trans('system.information.server.distribution', [], 'SystemInformationBundle'),
-            'value' => $this->getOSInformation()['pretty_name'] ?? 'Unknown',
+            'value' => $this->getOSInformation()['pretty_name'] ?? $this->translator->trans('system.information.server.error', [], 'SystemInformationBundle'),
         ];
     }
 
@@ -431,7 +431,7 @@ class InformationService
     {
         return [
             'label' => $this->translator->trans('system.information.app.version', [], 'SystemInformationBundle'),
-            'value' => $this->readAppVersion(),
+            'value' => $this->readAppVersion() ?? $this->translator->trans('system.information.app.error', [], 'SystemInformationBundle'),
         ];
     }
 
@@ -482,7 +482,7 @@ class InformationService
     /**
      * @return array
      */
-    public function getMailHost()
+    public function getMailHost(): array
     {
         return [
             'label' => $this->translator->trans('system.information.mail.host', [], 'SystemInformationBundle'),
@@ -640,9 +640,9 @@ class InformationService
     }
 
     /**
-     * @return array|false|int|string|null
+     * @return array|null
      */
-    public function getMailConfiguration(): array
+    public function getMailConfiguration(): ?array
     {
         $configuration = null;
         // Swiftmailer
@@ -655,12 +655,12 @@ class InformationService
             $configuration = parse_url($_ENV['MAILER_DSN']);
             $configuration['service'] = 'SymfonyMailer';
         }
-        return $configuration;
+        return $configuration ?: null;
     }
 
     /**
      * https://stackoverflow.com/a/42397673
-     * @return array|false|null
+     * @return array|null
      */
     private function getOSInformation(): ?array
     {

--- a/src/Service/InformationService.php
+++ b/src/Service/InformationService.php
@@ -332,7 +332,7 @@ class InformationService
     {
         return [
             'label' => $this->translator->trans('system.information.server.distribution', [], 'SystemInformationBundle'),
-            'value' => $this->getOSInformation()['pretty_name'],
+            'value' => $this->getOSInformation()['pretty_name'] ?? 'Unknown',
         ];
     }
 

--- a/src/Twig/VersionExtension.php
+++ b/src/Twig/VersionExtension.php
@@ -37,9 +37,9 @@ class VersionExtension extends AbstractExtension
     }
 
     /**
-     * @return mixed|null
+     * @return string|null
      */
-    public function getComposerVersion(): mixed
+    public function getComposerVersion(): ?string
     {
         return $this->informationService->readAppVersion();
     }


### PR DESCRIPTION
if system distribution can't be detected - this could caused by server restrictions - an exception is thrown. This PR prevents the exception and displays 'Unknown' for distribution option.